### PR TITLE
Changed the addon name in addon_config.mk

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -15,7 +15,7 @@
 # and the PG will write to the console the kind of error and in which line it is
 
 meta:
-	ADDON_NAME = ofxOsc
+	ADDON_NAME = ofxOscBidirectional
 	ADDON_DESCRIPTION = Addon for bidirectional communicating with the OSC protocol
 	ADDON_AUTHOR = <elgiano@gmail.com>
 	ADDON_TAGS = "networking"


### PR DESCRIPTION
From ofxOsc to ofxOscBidirectional.
Otherwise the commandline projectGenerator throws an error:
```
[ error ] Error parsing ofxOscBidirectional addon_config.mk
line 18: 	ADDON_NAME = ofxOsc
addon name in filesystem ofxOscBidirectional doesn't match with addon_config.mk ofxOsc
```